### PR TITLE
Various fixes/changes

### DIFF
--- a/alarmdecoder/Dockerfile
+++ b/alarmdecoder/Dockerfile
@@ -35,7 +35,6 @@ RUN sudo apt-get update && sudo apt-get install -y \
     sendmail \
     sqlite3 \
     git \
-    rpi-update \
     miniupnpc \
     python2.7 \
     python2.7-dev \
@@ -69,19 +68,9 @@ WORKDIR /opt
 
 RUN sudo rm /etc/default/locale
 
-RUN echo 'LANG="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_NUMERIC="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_MONETARY="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_PAPER="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_NAME="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_ADDRESS="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_TELEPHONE="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_MEASUREMENT="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo 'LC_IDENTIFICATION="en_US.UTF-8"' | sudo tee -a /etc/default/locale
-RUN echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
+RUN echo 'LANG=C.UTF-8' | sudo tee /etc/default/locale
 RUN sudo ln -s /etc/locale/alias /usr/share/locale/locale.alias
 #RUN sudo dpkg-reconfigure locales
-RUN sudo locale-gen
 
 RUN sudo pip install setuptools
 #install ser2sock and alarmdecoder python library
@@ -102,15 +91,11 @@ RUN sudo update-rc.d ser2sock defaults
 WORKDIR /opt/alarmdecoder
 RUN sudo python setup.py install
 
-#configurations
-RUN sudo echo "enable_uart=1" >> /boot/config.txt
-RUN sudo rpi-update
-
 #install nginx by source
 RUN sudo service nginx stop
 RUN sudo apt-get -y remove nginx nginx-full
 RUN sudo apt-get clean
-ENV VERSION 1.7.4
+ENV VERSION 1.12.1
 WORKDIR /home/pi
 RUN curl http://nginx.org/download/nginx-$VERSION.tar.gz | tar zxvf -
 WORKDIR /home/pi/nginx-$VERSION

--- a/alarmdecoder/Dockerfile
+++ b/alarmdecoder/Dockerfile
@@ -64,8 +64,6 @@ RUN sudo echo -e '<?xml version="1.0" standalone="no"?>\n\
 # Define working directory
 WORKDIR /opt
 
-RUN sudo rm /etc/default/locale
-
 RUN echo 'LANG=C.UTF-8' | sudo tee /etc/default/locale
 RUN sudo ln -s /etc/locale/alias /usr/share/locale/locale.alias
 #RUN sudo dpkg-reconfigure locales

--- a/alarmdecoder/Dockerfile
+++ b/alarmdecoder/Dockerfile
@@ -22,7 +22,6 @@ RUN sudo apt-get update && sudo apt-get install -y \
     avahi-daemon \
     libffi-dev \
     screen \
-    dosfstools \
     nginx \
     curl \
     build-essential \

--- a/alarmdecoder/Dockerfile
+++ b/alarmdecoder/Dockerfile
@@ -22,7 +22,6 @@ RUN sudo apt-get update && sudo apt-get install -y \
     avahi-daemon \
     libffi-dev \
     screen \
-    locales \
     dosfstools \
     nginx \
     curl \

--- a/alarmdecoder/Dockerfile
+++ b/alarmdecoder/Dockerfile
@@ -25,7 +25,6 @@ RUN sudo apt-get update && sudo apt-get install -y \
     locales \
     dosfstools \
     nginx \
-    vim \
     curl \
     build-essential \
     libpcre3-dev \

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ source config.cfg
 
 echo "enable_uart=1" | sudo tee -a /boot/config.txt
 
-echo "Checking if uart enabled...." >&2
+echo "Checking if the uart is enabled...." >&2
 if sudo grep "enable_uart=1" /boot/config.txt
 then
     echo "disabling serial console..." >&2

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ then
 
     sudo sed -i 's/frontend=pager/frontend=text/g' /etc/apt/listchanges.conf
     sudo apt-get update
-    sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates vim
+    sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates
 
     if [ $? != 0 ]; then
         echo "Unable to install some required packages...." >&2

--- a/install.sh
+++ b/install.sh
@@ -5,62 +5,62 @@ source config.cfg
 echo "enable_uart=1" | sudo tee -a /boot/config.txt
 
 echo "Checking if the uart is enabled...." >&2
-if sudo grep "enable_uart=1" /boot/config.txt
-then
-    echo "disabling serial console..." >&2
-    sudo sed -i 's/console=serial0,115200/ /g' /boot/cmdline.txt
-    sudo sed -i 's/kgdbog=ttyAMA0,115200/ /g' /boot/cmdline.txt
 
-    sudo sed -i 's/frontend=pager/frontend=text/g' /etc/apt/listchanges.conf
-    sudo apt-get update
-    sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates
-
-    if [ $? != 0 ]; then
-        echo "Unable to install some required packages...." >&2
-        exit 1
-    fi
-
-    sudo systemctl disable serial-getty@ttyAMA0.service
-    echo "alarmdecoder" | sudo tee /etc/hostname
-    sudo sed -i 's/raspberrypi/alarmdecoder/g' /etc/hosts
-    sudo /etc/init.d/hostname.sh start
-
-    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
-
-    sudo apt-get update
-    sudo apt-get install -y --force-yes docker-engine
-
-    if [ $? != 0 ]; then
-        echo "Unable to install docker-engine...." >&2
-        exit 1
-    fi
-    sudo systemctl enable docker.service
-    sudo service docker start
-    sudo groupadd docker
-    sudo gpasswd -a ${USER} docker
-    sudo service docker restart
-
-    docker build -t alarmdecoder alarmdecoder
-
-    if [ $? != 0 ]; then
-        echo "Failed to build docker container..." >&2
-        exit 1
-    fi
-
-    sudo docker run --restart $RESTART_PARAM -v /usr/local/bin:/target jpetazzo/nsenter
-
-    sudo docker run --restart $RESTART_PARAM --net="host" --device=$DEVICE --privileged -d -ti -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p $EXTERNAL_HTTP_PORT:$INTERNAL_HTTP_PORT -p $EXTERNAL_HTTPS_PORT:$INTERNAL_HTTPS_PORT -p $EXTERNAL_WORKER_PORT:$INTERNAL_WORKER_PORT -p $EXTERNAL_SER2SOCK_PORT:$INTERNAL_SER2SOCK_PORT alarmdecoder
-
-    if [ $? != 0 ]
-    then
-        echo "Failed to run docker container..." >&2
-        exit 1
-    else
-        echo "Seems everything went OK - please reboot to finish..." >&2
-        exit 0
-    fi
-else
+if ! sudo grep "enable_uart=1" /boot/config.txt; then
     echo "enable_uart=1 not found in /boot/config.txt...this is a manual step that must be done as root - exiting" >&2
     exit 1
+fi
+
+echo "disabling serial console..." >&2
+sudo sed -i 's/console=serial0,115200/ /g' /boot/cmdline.txt
+sudo sed -i 's/kgdbog=ttyAMA0,115200/ /g' /boot/cmdline.txt
+
+sudo sed -i 's/frontend=pager/frontend=text/g' /etc/apt/listchanges.conf
+sudo apt-get update
+sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates
+
+if [ $? != 0 ]; then
+    echo "Unable to install some required packages...." >&2
+    exit 1
+fi
+
+sudo systemctl disable serial-getty@ttyAMA0.service
+echo "alarmdecoder" | sudo tee /etc/hostname
+sudo sed -i 's/raspberrypi/alarmdecoder/g' /etc/hosts
+sudo /etc/init.d/hostname.sh start
+
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
+
+sudo apt-get update
+sudo apt-get install -y --force-yes docker-engine
+
+if [ $? != 0 ]; then
+    echo "Unable to install docker-engine...." >&2
+    exit 1
+fi
+
+sudo systemctl enable docker.service
+sudo service docker start
+sudo groupadd docker
+sudo gpasswd -a ${USER} docker
+sudo service docker restart
+
+docker build -t alarmdecoder alarmdecoder
+
+if [ $? != 0 ]; then
+    echo "Failed to build docker container..." >&2
+    exit 1
+fi
+
+sudo docker run --restart $RESTART_PARAM -v /usr/local/bin:/target jpetazzo/nsenter
+
+sudo docker run --restart $RESTART_PARAM --net="host" --device=$DEVICE --privileged -d -ti -e "container=docker" -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p $EXTERNAL_HTTP_PORT:$INTERNAL_HTTP_PORT -p $EXTERNAL_HTTPS_PORT:$INTERNAL_HTTPS_PORT -p $EXTERNAL_WORKER_PORT:$INTERNAL_WORKER_PORT -p $EXTERNAL_SER2SOCK_PORT:$INTERNAL_SER2SOCK_PORT alarmdecoder
+
+if [ $? != 0 ]; then
+    echo "Failed to run docker container..." >&2
+    exit 1
+else
+    echo "Seems everything went OK - please reboot to finish..." >&2
+    exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -29,20 +29,28 @@ echo "alarmdecoder" | sudo tee /etc/hostname
 sudo sed -i 's/raspberrypi/alarmdecoder/g' /etc/hosts
 sudo /etc/init.d/hostname.sh start
 
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
+DEBIAN_VERSION=$(awk 'BEGIN { FS = "" } { print $1 }' /etc/debian_version)
+if [ $DEBIAN_VERSION -lt 9 ]; then
+    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+    echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
 
-sudo apt-get update
-sudo apt-get install -y --force-yes docker-engine
+    sudo apt-get update
+    sudo apt-get install -y --force-yes docker-engine
+else
+    sudo apt-get install -y --force-yes docker.io
+fi
 
 if [ $? != 0 ]; then
     echo "Unable to install docker-engine...." >&2
     exit 1
 fi
 
+if [ $DEBIAN_VERSION -lt 9 ]; then
+    sudo groupadd docker
+fi
+
 sudo systemctl enable docker.service
 sudo service docker start
-sudo groupadd docker
 sudo gpasswd -a ${USER} docker
 sudo service docker restart
 

--- a/pull.sh
+++ b/pull.sh
@@ -21,19 +21,28 @@ fi
 
 echo "alarmdecoder" | sudo tee /etc/hostname
 
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
-echo "installing docker-engine..." >&2
-sudo apt-get update
-sudo apt-get install -y --force-yes docker-engine
+DEBIAN_VERSION=$(awk 'BEGIN { FS = "" } { print $1 }' /etc/debian_version)
+if [ $DEBIAN_VERSION -lt 9 ]; then
+    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+    echo "deb https://apt.dockerproject.org/repo raspbian-jessie main" | sudo tee /etc/apt/sources.list.d/docker.list
+    echo "installing docker-engine..." >&2
+    sudo apt-get update
+    sudo apt-get install -y --force-yes docker-engine
+else
+    sudo apt-get install -y --force-yes docker.io
+fi
 
 if [ $? != 0 ]; then
     echo "Failed to install docker-engine...." >&2
     exit 1
 fi
+
+if [ $DEBIAN_VERSION -lt 9 ]; then
+   sudo groupadd docker
+fi
+
 sudo systemctl enable docker.service
 sudo service docker start
-sudo groupadd docker
 sudo gpasswd -a ${USER} docker
 sudo service docker restart
 

--- a/pull.sh
+++ b/pull.sh
@@ -45,6 +45,7 @@ if [ $? != 0 ]; then
     echo "Failed to pull alarmdecoder image..." >&2
     exit 1
 fi
+
 sudo hostname alarmdecoder
 sudo sed -i 's/raspberrypi/alarmdecoder/g' /etc/hosts
 sudo /etc/init.d/hostname.sh start

--- a/pull.sh
+++ b/pull.sh
@@ -12,7 +12,7 @@ echo "preparing dependencies..." >&2
 
 sudo sed -i 's/frontend=pager/frontend=text/g' /etc/apt/listchanges.conf
 sudo apt-get update
-sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates vim
+sudo apt-get install -y --force-yes rpi-update apt-transport-https ca-certificates
 
 if [ $? != 0 ]; then
     echo "Unable to install some required packages..." >&2


### PR DESCRIPTION
Sorry about putting these all in one PR. I  can break it out if needed.

- I cleaned up install.sh to make it easier to read
- Added Stretch host support to both scripts
- Removed force installing vim, users can install it if they want it
- Running rpi-update and changing  boot settings inside a container doesn't really makes sense
- nginx 1.7.x is full of vulnerabiities
- Debian's glibc has C.UTF-8 support.  This gives you UTF-8 without forcing a locale's particularities on a user, like change LC_COLLATE sorting rules.  It's also built-in to glibc, so it doesn't require installing the locales package and updating generated locales.

Also personally I changed my container to run everything under a 'alarmdecoder' user instead of build a 'pi' user in the container, as that makes more sense to me.  I can submit that as a separate PR.